### PR TITLE
Enhance Error Handling with Descriptive Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ let request = NetworkRequest<VoidRequest, SearchResults>(
 
 ## Error Handling
 
-MicroClient provides structured error handling:
+MicroClient provides structured error handling through the `NetworkClientError` enum, giving you detailed information on what went wrong.
 
 ```swift
 do {
@@ -306,12 +306,33 @@ do {
 } catch let error as NetworkClientError {
     switch error {
     case .malformedURL:
-        // Handle invalid URL
-    case .unknown:
-        // Handle unknown errors
+        print("Error: The URL for the request was invalid.")
+
+    case .transportError(let underlyingError):
+        print("Error: A network transport error occurred: \(underlyingError.localizedDescription)")
+
+    case .unacceptableStatusCode(let statusCode, _, let data):
+        print("Error: Server returned an unacceptable status code: \(statusCode).")
+        if let data = data, let errorBody = String(data: data, encoding: .utf8) {
+            print("Server response: \(errorBody)")
+        }
+
+    case .decodingError(let underlyingError):
+        print("Error: Failed to decode the response: \(underlyingError.localizedDescription)")
+
+    case .encodingError(let underlyingError):
+        print("Error: Failed to encode the request body: \(underlyingError.localizedDescription)")
+
+    case .unknown(let underlyingError):
+        if let underlyingError = underlyingError {
+            print("An unknown error occurred: \(underlyingError.localizedDescription)")
+        } else {
+            print("An unknown error occurred.")
+        }
     }
 } catch {
-    // Handle other errors
+    // Handle any other errors
+    print("An unexpected error occurred: \(error.localizedDescription)")
 }
 ```
 

--- a/Sources/MicroClient/NetworkClientError.swift
+++ b/Sources/MicroClient/NetworkClientError.swift
@@ -1,10 +1,28 @@
-/// Network client errors when building requests.
-public enum NetworkClientError: Error {
+import Foundation
 
-    /// Invalid URL. Either when building URL components
-    /// or with the base URL.
+/// An enum representing possible errors that can occur during a network request.
+public enum NetworkClientError: Error {
+    /// The URL for the request was malformed or invalid.
     case malformedURL
 
-    /// An unknown error.
-    case unknown
+    /// The request failed due to an underlying transport error, such as a lost network connection.
+    /// The associated `Error` value contains the original error from the URLSession.
+    case transportError(Error)
+
+    /// The server returned a response with an HTTP status code indicating an error (i.e., not in the 200-299 range).
+    /// - `statusCode`: The HTTP status code returned by the server.
+    /// - `response`: The metadata associated with the HTTP response.
+    /// - `data`: The raw response body, which may contain more specific error details from the server.
+    case unacceptableStatusCode(statusCode: Int, response: URLResponse, data: Data?)
+
+    /// The response body could not be decoded into the expected `Decodable` type.
+    /// The associated `Error` value contains the original decoding error.
+    case decodingError(Error)
+
+    /// The response body could not be encoded into the expected `Encodable` type.
+    /// The associated `Error` value contains the original decoding error.
+    case encodingError(Error)
+
+    /// An unexpected or unknown error occurred.
+    case unknown(Error?)
 }

--- a/Tests/MicroClientTests/NetworkClientLoggingTests.swift
+++ b/Tests/MicroClientTests/NetworkClientLoggingTests.swift
@@ -79,8 +79,8 @@ struct NetworkClientLoggingTests {
         _ = try? await client.run(request)
 
         #expect(
-            mockLogger.loggedMessages.contains(where: { $0.level == .error && $0.message.contains("Error:") }),
-            "It should log error"
+            mockLogger.loggedMessages.contains(where: { $0.level == .error && $0.message.contains("Transport error:") }),
+            "It should log a transport error"
         )
     }
 

--- a/Tests/MicroClientTests/NetworkClientTests.swift
+++ b/Tests/MicroClientTests/NetworkClientTests.swift
@@ -107,12 +107,11 @@ struct NetworkClientTests {
 
         do {
             _ = try await client.run(request)
-            #expect(Bool(false), "It should throw network error")
+            #expect(Bool(false), "It should throw a network error")
+        } catch let NetworkClientError.transportError(underlyingError) {
+            #expect(underlyingError is URLError, "The underlying error should be a URLError")
         } catch {
-            #expect(
-                error is URLError,
-                "It should propagate URLError"
-            )
+            #expect(Bool(false), "It should have thrown a NetworkClientError.transportError, but threw \(error) instead")
         }
     }
 


### PR DESCRIPTION
Refactors the `NetworkClientError` enum to provide more specific and descriptive error cases.